### PR TITLE
DestructiveFilePath.ToString glitch

### DIFF
--- a/src/Mio/Destructive/DestructiveFilePath.cs
+++ b/src/Mio/Destructive/DestructiveFilePath.cs
@@ -26,7 +26,7 @@ namespace Mio.Destructive
 
         [Pure]
         public override string ToString()
-            => "<DestructiveDir: " + this.FullName + ">";
+            => "<DestructiveFile: " + this.FullName + ">";
 
         [NotNull]
         public static DestructiveFilePath CreateTempFile()
@@ -52,7 +52,7 @@ namespace Mio.Destructive
 
         public bool Delete()
         {
-            if (!F.Exists(this.FullName)) return false;
+            if (F.Exists(this.FullName)) return false;
             try
             {
                 F.Delete(this.FullName);


### PR DESCRIPTION
Return value starts with DestructiveDir -- should be, DestructiveFile.